### PR TITLE
fix(email): hard timeout and graceful failure for password reset SMTP

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -32,12 +32,23 @@ CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS').split(',') if os.getenv
 SECRET_KEY = os.getenv('SECRET_KEY')
 RECAPTCHA_SECRET_KEY = os.getenv('RECAPTCHA_SECRET_KEY')
 
+def _env_bool(name, default=False):
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
 EMAIL_BACKEND = os.getenv("EMAIL_BACKEND")
 EMAIL_HOST = os.getenv("EMAIL_HOST")
-EMAIL_PORT = os.getenv("EMAIL_PORT")
-EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", "587"))
+EMAIL_USE_TLS = _env_bool("EMAIL_USE_TLS", default=True)
+EMAIL_USE_SSL = _env_bool("EMAIL_USE_SSL", default=False)
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
+# Hard timeout for SMTP connect/read so requests fail fast instead of being
+# killed by the gunicorn worker timeout.
+EMAIL_TIMEOUT = int(os.getenv("EMAIL_TIMEOUT", "10"))
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/backend/base/User/views.py
+++ b/backend/base/User/views.py
@@ -1,5 +1,8 @@
+import logging
 import os
+import socket
 from email.mime.image import MIMEImage
+from smtplib import SMTPException
 
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.tokens import default_token_generator
@@ -16,6 +19,8 @@ from django.contrib.auth.models import User
 from .serializers import UserSerializer
 from ..permission_classes import IsSelfOrAdmin
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 
 @permission_classes([IsAuthenticated, IsAdminUser])
@@ -81,7 +86,15 @@ def forgot_password(request):
     logo.add_header('Content-Disposition', 'inline', filename="logo_cut.png")
     email.attach(logo)
 
-    email.send(fail_silently=False)
+    try:
+        email.send(fail_silently=False)
+    except (SMTPException, socket.timeout, socket.gaierror, ConnectionError, OSError) as exc:
+        logger.exception("Failed to send password reset email to %s: %s", user.email, exc)
+        return Response(
+            {"detail": "Unable to send the password reset email right now. Please try again later."},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
     return Response({"detail": "Password reset email sent."}, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
The forgot_password view called email.send() synchronously with no SMTP timeout, so an unreachable SMTP server caused gunicorn to kill the worker after its own timeout (handle_abort -> SystemExit). The frontend spinner then ran forever because the request was never replied to.

- settings.py: coerce EMAIL_PORT to int and EMAIL_USE_TLS / EMAIL_USE_SSL to real booleans (env vars are strings; "False" was previously truthy). Add EMAIL_TIMEOUT (default 10s) so SMTP fails fast.
- User/views.py: wrap email.send() in try/except for SMTP/socket errors, log the exception, and return 503 so the client gets a response instead of hanging until the worker dies.