### PR TITLE
fix(frontend): serve built dist over a static server on Railway

### DIFF
--- a/frontend/railway.json
+++ b/frontend/railway.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://railway.app/railway.schema.json",
+    "build": {
+        "builder": "NIXPACKS",
+        "buildCommand": "npm ci && npm run build"
+    },
+    "deploy": {
+        "startCommand": "npx --yes serve -s dist -l $PORT"
+    }
+}


### PR DESCRIPTION
Production was serving the raw Vite source files. The browser fetched /src/main.tsx with a text/plain MIME type, which Chrome refuses to execute as an ES module under strict MIME checking, leaving the page blank.

Add frontend/railway.json so the build runs `npm ci && npm run build` and the deploy starts `serve -s dist -l $PORT`. The -s flag rewrites unknown routes to index.html so client-side React Router paths keep working on refresh, and `serve` returns the correct application/javascript MIME for the bundled module scripts.