### PR TITLE
fix(frontend): use npm install instead of npm ci to avoid EBUSY in Ni…

### DIFF
--- a/frontend/railway.json
+++ b/frontend/railway.json
@@ -2,7 +2,7 @@
     "$schema": "https://railway.app/railway.schema.json",
     "build": {
         "builder": "NIXPACKS",
-        "buildCommand": "npm ci && npm run build"
+        "buildCommand": "npm install --no-audit --no-fund && npm run build"
     },
     "deploy": {
         "startCommand": "npx --yes serve -s dist -l $PORT"


### PR DESCRIPTION
…xpacks

The previous PR (#4) was squash-merged using only its first commit, so the build command on prod is still `npm ci && npm run build`. That fails on Railway/Nixpacks with `EBUSY: resource busy or locked, rmdir '/app/node_modules/.cache'` because `npm ci` wipes node_modules first and the cache directory is held open / on a cache mount.

Switch the build command to `npm install --no-audit --no-fund`, which still respects the lockfile but does not perform the destructive pre-wipe.