### PR TITLE
Fix Resend send failure from inline logo CID

### DIFF
--- a/backend/base/User/views.py
+++ b/backend/base/User/views.py
@@ -1,6 +1,4 @@
 import logging
-import os
-from email.mime.image import MIMEImage
 
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.tokens import default_token_generator
@@ -81,14 +79,6 @@ def forgot_password(request):
     )
 
     message.attach_alternative(email_html_body, "text/html")
-
-    image_path = os.path.join(settings.BASE_DIR, 'static', 'images', 'logo_cut.png')
-    with open(image_path, "rb") as f:
-        logo_data = f.read()
-    logo = MIMEImage(logo_data)
-    logo.add_header('Content-ID', '<logo_cut>')
-    logo.add_header('Content-Disposition', 'inline', filename="logo_cut.png")
-    message.attach(logo)
 
     try:
         message.send(fail_silently=False)

--- a/backend/base/signals.py
+++ b/backend/base/signals.py
@@ -1,5 +1,3 @@
-import os
-
 from django.db.models.signals import pre_save
 from django.contrib.auth.models import User
 from django.dispatch import Signal
@@ -10,8 +8,6 @@ from base.models import Order
 
 from django.core.mail import EmailMultiAlternatives
 from django.utils.html import strip_tags
-
-from email.mime.image import MIMEImage
 
 
 def update_user(sender, instance, **kwargs):
@@ -72,18 +68,7 @@ def send_order_confirmation_email(sender, order, **kwargs):
         [user.email],
     )
 
-    # Attach the HTML version of the email
     email.attach_alternative(email_html_body, "text/html")
-
-    # Attach the company logo
-    image_path = os.path.join(settings.BASE_DIR, 'static', 'images', 'logo_cut.png')
-    with open(image_path, "rb") as f:
-        logo_data = f.read()
-    logo = MIMEImage(logo_data)
-    logo.add_header('Content-ID', '<logo_cut>')
-    logo.add_header('Content-Disposition', 'inline', filename="logo_cut.png")
-    email.attach(logo)
-
     email.send(fail_silently=False)
 
     send_order_confirmation_update_to_owner(order)
@@ -114,18 +99,7 @@ def send_order_confirmation_email_shipped(sender, order, **kwargs):
         [user.email],
     )
 
-    # Attach the HTML version of the email
     email.attach_alternative(email_html_body, "text/html")
-
-    # Attach the company logo
-    image_path = os.path.join(settings.BASE_DIR, 'static', 'images', 'logo_cut.png')
-    with open(image_path, "rb") as f:
-        logo_data = f.read()
-    logo = MIMEImage(logo_data)
-    logo.add_header('Content-ID', '<logo_cut>')
-    logo.add_header('Content-Disposition', 'inline', filename="logo_cut.png")
-    email.attach(logo)
-
     email.send(fail_silently=False)
 
 
@@ -155,18 +129,7 @@ def send_order_confirmation_email_delivered(sender, order, **kwargs):
         [user.email],
     )
 
-    # Attach the HTML version of the email
     email.attach_alternative(email_html_body, "text/html")
-
-    # Attach the company logo
-    image_path = os.path.join(settings.BASE_DIR, 'static', 'images', 'logo_cut.png')
-    with open(image_path, "rb") as f:
-        logo_data = f.read()
-    logo = MIMEImage(logo_data)
-    logo.add_header('Content-ID', '<logo_cut>')
-    logo.add_header('Content-Disposition', 'inline', filename="logo_cut.png")
-    email.attach(logo)
-
     email.send(fail_silently=False)
 
 

--- a/backend/base/templates/PasswordResetEmail.html
+++ b/backend/base/templates/PasswordResetEmail.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div>
-      <img src="cid:logo_cut" alt="Annedora" style="max-width: 800px" />
+      <img src="https://annedora.ca/images/logo_cut.png" alt="Annedora" style="max-width: 800px" />
       <h2>Password Reset Request</h2>
       <p>Dear {{ user }},</p>
       <p>To reset your password, please click the following link: </p>

--- a/backend/base/templates/UserOrderConfirmation.html
+++ b/backend/base/templates/UserOrderConfirmation.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div>
-      <img src="cid:logo_cut" alt="Annedora" style="max-width: 800px" />
+      <img src="https://annedora.ca/images/logo_cut.png" alt="Annedora" style="max-width: 800px" />
       <h2>Order Confirmation</h2>
       <p>Dear {{ user.first_name }},</p>
       <p>Thank you for your order!</p>

--- a/backend/base/templates/UserOrderConfirmationDelivered.html
+++ b/backend/base/templates/UserOrderConfirmationDelivered.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div>
-      <img src="cid:logo_cut" alt="Annedora" style="max-width: 800px" />
+      <img src="https://annedora.ca/images/logo_cut.png" alt="Annedora" style="max-width: 800px" />
 
         {% if order.order_option == 'Pick-up' %}
           <h2>Your order was fulfilled !</h2>

--- a/backend/base/templates/UserOrderConfirmationShipped.html
+++ b/backend/base/templates/UserOrderConfirmationShipped.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div>
-      <img src="cid:logo_cut" alt="Annedora" style="max-width: 800px" />
+      <img src="https://annedora.ca/images/logo_cut.png" alt="Annedora" style="max-width: 800px" />
       <h2>Your order was shipped !</h2>
       <p>Dear {{ user.first_name }},</p>
       <p>Your order is on its way!</p>


### PR DESCRIPTION
## Summary
- Resend rejects inline `content-id` attachments (`AnymailUnsupportedFeature`), which is why password-reset mail never sent.
- Stop attaching the logo as CID; reference `https://annedora.ca/images/logo_cut.png` in reset and order email templates.

## Test plan
- [ ] Deploy backend, then request a password reset
- [ ] Confirm the message appears in Resend Emails and arrives in the inbox
- [ ] Railway logs no longer show `Resend does not support inline content-id`