### PR TITLE
Show Annedora as the email sender name

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -40,7 +40,15 @@ def _env_bool(name, default=False):
 
 
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)
+_default_from = os.getenv("DEFAULT_FROM_EMAIL")
+if _default_from:
+    DEFAULT_FROM_EMAIL = _default_from
+elif EMAIL_HOST_USER and "<" in EMAIL_HOST_USER:
+    DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+elif EMAIL_HOST_USER:
+    DEFAULT_FROM_EMAIL = f"Annedora <{EMAIL_HOST_USER}>"
+else:
+    DEFAULT_FROM_EMAIL = "Annedora <info@annedora.ca>"
 
 # Prefer Resend's HTTPS API when an API key is present. Railway Hobby blocks
 # outbound SMTP (25/465/587), so IONOS SMTP will time out there.

--- a/backend/base/ContactForm/views.py
+++ b/backend/base/ContactForm/views.py
@@ -5,7 +5,6 @@ from rest_framework import status
 from django.core.mail import send_mail
 from django.conf import settings
 
-from backend.settings import EMAIL_HOST_USER
 from base.ContactForm.serializer import ContactFormSerializer
 
 
@@ -49,7 +48,7 @@ class ContactFormView(APIView):
             Surface Area: {surface_area}
             Produce: {produce}
             """
-            from_email = settings.EMAIL_HOST_USER
+            from_email = settings.DEFAULT_FROM_EMAIL
             recipient_list = ['valentin.prunoiu@annedora.ca']
 
             # Send email

--- a/backend/base/User/views.py
+++ b/backend/base/User/views.py
@@ -74,7 +74,7 @@ def forgot_password(request):
     message = EmailMultiAlternatives(
         email_subject,
         email_text_body,
-        settings.EMAIL_HOST_USER,
+        settings.DEFAULT_FROM_EMAIL,
         [user.email],
     )
 

--- a/backend/base/signals.py
+++ b/backend/base/signals.py
@@ -36,7 +36,7 @@ def send_order_confirmation_update_to_owner(order):
     email = EmailMultiAlternatives(
         email_subject,
         email_text_body,
-        settings.EMAIL_HOST_USER,
+        settings.DEFAULT_FROM_EMAIL,
         ['valentin.prunoiu@annedora.ca'],
     )
 
@@ -64,7 +64,7 @@ def send_order_confirmation_email(sender, order, **kwargs):
     email = EmailMultiAlternatives(
         email_subject,
         email_text_body,
-        settings.EMAIL_HOST_USER,
+        settings.DEFAULT_FROM_EMAIL,
         [user.email],
     )
 
@@ -95,7 +95,7 @@ def send_order_confirmation_email_shipped(sender, order, **kwargs):
     email = EmailMultiAlternatives(
         email_subject,
         email_text_body,
-        settings.EMAIL_HOST_USER,
+        settings.DEFAULT_FROM_EMAIL,
         [user.email],
     )
 
@@ -125,7 +125,7 @@ def send_order_confirmation_email_delivered(sender, order, **kwargs):
     email = EmailMultiAlternatives(
         email_subject,
         email_text_body,
-        settings.EMAIL_HOST_USER,
+        settings.DEFAULT_FROM_EMAIL,
         [user.email],
     )
 


### PR DESCRIPTION
## Summary
- Send mail as `Annedora <mailbox>` instead of a bare `no-reply@...` address so Gmail shows Annedora rather than `no-reply`.
- Applies to password reset, order emails, and the pollination contact form.

## Test plan
- [ ] Deploy backend, then trigger a password reset
- [ ] Confirm the inbox sender name is Annedora (avatar is still Gmail/BIMI, not this change)